### PR TITLE
Improve support for native compilation in the wasm build

### DIFF
--- a/src/backend/access/common/printtup.c
+++ b/src/backend/access/common/printtup.c
@@ -567,5 +567,7 @@ debugtup_json_shutdown(DestReceiver *self)
 {
 	appendStringInfoChar(&json_result, ']');
 	appendStringInfoChar(&json_result, '\0');
+#ifdef EMSCRIPTEN
 	dispatch_result(json_result.data);
+#endif
 }

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -342,6 +342,7 @@ interactive_getc(void)
 	return c;
 }
 
+#ifdef EMSCRIPTEN
 /* ----------------
  *	EmscriptenBackend()
  *
@@ -380,6 +381,7 @@ EmscriptenBackend(StringInfo inBuf)
 
 	return 'Q';
 }
+#endif
 
 /* ----------------
  *	SocketBackend()		Is called for frontend-backend connections
@@ -524,8 +526,10 @@ ReadCommand(StringInfo inBuf)
 
 	if (whereToSendOutput == DestRemote)
 		result = SocketBackend(inBuf);
+#ifdef EMSCRIPTEN
 	else if (whereToSendOutput == DestDebugJson)
 		result = EmscriptenBackend(inBuf);
+#endif
 	else
 		result = InteractiveBackend(inBuf);
 	return result;


### PR DESCRIPTION
I have been playing around with pglite, trying to see if it still compiles natively, because that would be interesting to use as well. It doesn't compile right now. I am not sure keeping native compilation is in scope of the `postgres-wasm` project, but this PR improves it.

As it is now, `src/backend/Makefile` still has to be modified. Ideally, a `PORTNAME=emscripten` should be added.