### PR TITLE
Enable dynamically loaded postgres extensions

### DIFF
--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -7590,7 +7590,7 @@ StartupXLOG(void)
 						 * of postmaster.  Log messages issued from
 						 * postmaster.
 						 */
-						proc_exit(3);
+						pg_proc_exit(3);
 
 					case RECOVERY_TARGET_ACTION_PAUSE:
 						SetRecoveryPause(true);

--- a/src/backend/access/transam/xlogarchive.c
+++ b/src/backend/access/transam/xlogarchive.c
@@ -254,7 +254,7 @@ RestoreArchivedFile(char *path, const char *xlogfname,
 	 * We treat hard shell errors such as "command not found" as fatal, too.
 	 */
 	if (wait_result_is_signal(rc, SIGTERM))
-		proc_exit(1);
+		pg_proc_exit(1);
 
 	ereport(wait_result_is_any_signal(rc, true) ? FATAL : DEBUG2,
 			(errmsg("could not restore file \"%s\" from archive: %s",

--- a/src/backend/bootstrap/bootstrap.c
+++ b/src/backend/bootstrap/bootstrap.c
@@ -302,7 +302,7 @@ AuxiliaryProcessMain(int argc, char *argv[])
 			default:
 				write_stderr("Try \"%s --help\" for more information.\n",
 							 progname);
-				proc_exit(1);
+				pg_proc_exit(1);
 				break;
 		}
 	}
@@ -310,7 +310,7 @@ AuxiliaryProcessMain(int argc, char *argv[])
 	if (argc != optind)
 	{
 		write_stderr("%s: invalid command-line arguments\n", progname);
-		proc_exit(1);
+		pg_proc_exit(1);
 	}
 
 	switch (MyAuxProcType)
@@ -343,7 +343,7 @@ AuxiliaryProcessMain(int argc, char *argv[])
 	if (!IsUnderPostmaster)
 	{
 		if (!SelectConfigFiles(userDoption, progname))
-			proc_exit(1);
+			pg_proc_exit(1);
 	}
 
 	checkDataDir();
@@ -431,7 +431,7 @@ AuxiliaryProcessMain(int argc, char *argv[])
 		case CheckerProcess:
 			/* don't set signals, they're useless here */
 			CheckerModeMain();
-			proc_exit(1);		/* should never return */
+			pg_proc_exit(1);		/* should never return */
 
 		case BootstrapProcess:
 
@@ -444,36 +444,36 @@ AuxiliaryProcessMain(int argc, char *argv[])
 			bootstrap_signals();
 			BootStrapXLOG();
 			BootstrapModeMain();
-			proc_exit(1);		/* should never return */
+			pg_proc_exit(1);		/* should never return */
 
 		case StartupProcess:
 			StartupProcessMain();
-			proc_exit(1);
+			pg_proc_exit(1);
 
 		case ArchiverProcess:
 			PgArchiverMain();
-			proc_exit(1);
+			pg_proc_exit(1);
 
 		case BgWriterProcess:
 			BackgroundWriterMain();
-			proc_exit(1);
+			pg_proc_exit(1);
 
 		case CheckpointerProcess:
 			CheckpointerMain();
-			proc_exit(1);
+			pg_proc_exit(1);
 
 		case WalWriterProcess:
 			InitXLOGAccess();
 			WalWriterMain();
-			proc_exit(1);
+			pg_proc_exit(1);
 
 		case WalReceiverProcess:
 			WalReceiverMain();
-			proc_exit(1);
+			pg_proc_exit(1);
 
 		default:
 			elog(PANIC, "unrecognized process type: %d", (int) MyAuxProcType);
-			proc_exit(1);
+			pg_proc_exit(1);
 	}
 }
 
@@ -486,7 +486,7 @@ AuxiliaryProcessMain(int argc, char *argv[])
 static void
 CheckerModeMain(void)
 {
-	proc_exit(0);
+	pg_proc_exit(0);
 }
 
 /*
@@ -561,7 +561,7 @@ BootstrapModeMain(void)
 
 	/* Clean up and exit */
 	cleanup();
-	proc_exit(0);
+	pg_proc_exit(0);
 }
 
 

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -1606,7 +1606,7 @@ ExecutePlan(EState *estate,
 	 * point.
 	 */
 	if (!(estate->es_top_eflags & EXEC_FLAG_BACKWARD))
-		(void) ExecShutdownNode(planstate);
+		ExecShutdownNode(planstate);
 
 	if (use_parallel_mode)
 		ExitParallelMode();

--- a/src/backend/executor/execProcnode.c
+++ b/src/backend/executor/execProcnode.c
@@ -121,6 +121,7 @@
 
 static TupleTableSlot *ExecProcNodeFirst(PlanState *node);
 static TupleTableSlot *ExecProcNodeInstr(PlanState *node);
+static bool ExecShutdownNode_walker(PlanState *node, void *context);
 
 
 /* ------------------------------------------------------------------------
@@ -768,8 +769,14 @@ ExecEndNode(PlanState *node)
  * Give execution nodes a chance to stop asynchronous resource consumption
  * and release any resources still held.
  */
-bool
+void
 ExecShutdownNode(PlanState *node)
+{
+	(void) ExecShutdownNode_walker(node, NULL);
+}
+
+static bool
+ExecShutdownNode_walker(PlanState *node, void *context)
 {
 	if (node == NULL)
 		return false;
@@ -789,7 +796,7 @@ ExecShutdownNode(PlanState *node)
 	if (node->instrument && node->instrument->running)
 		InstrStartNode(node->instrument);
 
-	planstate_tree_walker(node, ExecShutdownNode, NULL);
+	planstate_tree_walker(node, ExecShutdownNode_walker, context);
 
 	switch (nodeTag(node))
 	{

--- a/src/backend/libpq/auth.c
+++ b/src/backend/libpq/auth.c
@@ -264,7 +264,7 @@ auth_failed(Port *port, int status, char *logdetail)
 	 * events.)
 	 */
 	if (status == STATUS_EOF)
-		proc_exit(0);
+		pg_proc_exit(0);
 
 	switch (port->hba->auth_method)
 	{

--- a/src/backend/postmaster/autovacuum.c
+++ b/src/backend/postmaster/autovacuum.c
@@ -620,7 +620,7 @@ AutoVacLauncherMain(int argc, char *argv[])
 	{
 		if (!ShutdownRequestPending)
 			do_start_worker();
-		proc_exit(0);			/* done */
+		pg_proc_exit(0);			/* done */
 	}
 
 	AutoVacuumShmem->av_launcherpid = MyProcPid;
@@ -851,7 +851,7 @@ AutoVacLauncherShutdown(void)
 			(errmsg_internal("autovacuum launcher shutting down")));
 	AutoVacuumShmem->av_launcherpid = 0;
 
-	proc_exit(0);				/* done */
+	pg_proc_exit(0);				/* done */
 }
 
 /*
@@ -1589,7 +1589,7 @@ AutoVacWorkerMain(int argc, char *argv[])
 		 * callback was registered to do ProcKill, which will clean up
 		 * necessary state.
 		 */
-		proc_exit(0);
+		pg_proc_exit(0);
 	}
 
 	/* We can now handle ereport(ERROR) */
@@ -1721,7 +1721,7 @@ AutoVacWorkerMain(int argc, char *argv[])
 	 */
 
 	/* All done, go away */
-	proc_exit(0);
+	pg_proc_exit(0);
 }
 
 /*

--- a/src/backend/postmaster/bgworker.c
+++ b/src/backend/postmaster/bgworker.c
@@ -825,7 +825,7 @@ StartBackgroundWorker(void)
 		 */
 
 		/* and go away */
-		proc_exit(1);
+		pg_proc_exit(1);
 	}
 
 	/* We can now handle ereport(ERROR) */
@@ -875,7 +875,7 @@ StartBackgroundWorker(void)
 	entrypt(worker->bgw_main_arg);
 
 	/* ... and if it returns, we're done */
-	proc_exit(0);
+	pg_proc_exit(0);
 }
 
 /*

--- a/src/backend/postmaster/checkpointer.c
+++ b/src/backend/postmaster/checkpointer.c
@@ -586,7 +586,7 @@ HandleCheckpointerInterrupts(void)
 		pgstat_send_wal(true);
 
 		/* Normal exit from the checkpointer is here */
-		proc_exit(0);			/* done */
+		pg_proc_exit(0);			/* done */
 	}
 }
 

--- a/src/backend/postmaster/interrupt.c
+++ b/src/backend/postmaster/interrupt.c
@@ -42,7 +42,7 @@ HandleMainLoopInterrupts(void)
 	}
 
 	if (ShutdownRequestPending)
-		proc_exit(0);
+		pg_proc_exit(0);
 }
 
 /*
@@ -72,7 +72,7 @@ void
 SignalHandlerForCrashExit(SIGNAL_ARGS)
 {
 	/*
-	 * We DO NOT want to run proc_exit() or atexit() callbacks -- we're here
+	 * We DO NOT want to run pg_proc_exit() or atexit() callbacks -- we're here
 	 * because shared memory may be corrupted, so we don't want to try to
 	 * clean up our transaction.  Just nail the windows shut and get out of
 	 * town.  The callbacks wouldn't be safe to run from a signal handler,

--- a/src/backend/postmaster/pgarch.c
+++ b/src/backend/postmaster/pgarch.c
@@ -200,7 +200,7 @@ PgArchiverMain(void)
 
 	pgarch_MainLoop();
 
-	proc_exit(0);
+	pg_proc_exit(0);
 }
 
 /*

--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -4462,7 +4462,7 @@ BackendInitialize(Port *port)
 	 * already did any appropriate error reporting.
 	 */
 	if (status != STATUS_OK)
-		proc_exit(0);
+		pg_proc_exit(0);
 
 	/*
 	 * Now that we have the user and database name, we can set the process
@@ -5132,7 +5132,7 @@ ExitPostmaster(int status)
 	 * MUST		-- vadim 05-10-1999
 	 */
 
-	proc_exit(status);
+	pg_proc_exit(status);
 }
 
 /*
@@ -5316,7 +5316,7 @@ sigusr1_handler(SIGNAL_ARGS)
 /*
  * SIGTERM while processing startup packet.
  *
- * Running proc_exit() from a signal handler would be quite unsafe.
+ * Running pg_proc_exit() from a signal handler would be quite unsafe.
  * However, since we have not yet touched shared memory, we can just
  * pull the plug and exit without running any atexit handlers.
  *

--- a/src/backend/postmaster/startup.c
+++ b/src/backend/postmaster/startup.c
@@ -102,7 +102,7 @@ StartupProcShutdownHandler(SIGNAL_ARGS)
 	int			save_errno = errno;
 
 	if (in_restore_command)
-		proc_exit(1);
+		pg_proc_exit(1);
 	else
 		shutdown_requested = true;
 	WakeupRecovery();
@@ -165,7 +165,7 @@ HandleStartupProcInterrupts(void)
 	 * Check if we were requested to exit without finishing recovery.
 	 */
 	if (shutdown_requested)
-		proc_exit(1);
+		pg_proc_exit(1);
 
 	/*
 	 * Emergency bailout if postmaster has died.  This is to avoid the
@@ -247,7 +247,7 @@ StartupProcessMain(void)
 	 * Exit normally. Exit code 0 tells postmaster that we completed recovery
 	 * successfully.
 	 */
-	proc_exit(0);
+	pg_proc_exit(0);
 }
 
 void
@@ -261,7 +261,7 @@ PreRestoreCommand(void)
 	 */
 	in_restore_command = true;
 	if (shutdown_requested)
-		proc_exit(1);
+		pg_proc_exit(1);
 }
 
 void

--- a/src/backend/postmaster/syslogger.c
+++ b/src/backend/postmaster/syslogger.c
@@ -528,7 +528,7 @@ SysLoggerMain(int argc, char *argv[])
 			 * inside proc_exit.  Regular exit() will take care of flushing
 			 * and closing stdio channels.
 			 */
-			proc_exit(0);
+			pg_proc_exit(0);
 		}
 	}
 }

--- a/src/backend/postmaster/walwriter.c
+++ b/src/backend/postmaster/walwriter.c
@@ -304,6 +304,6 @@ HandleWalWriterInterrupts(void)
 		 */
 		pgstat_send_wal(true);
 
-		proc_exit(0);
+		pg_proc_exit(0);
 	}
 }

--- a/src/backend/replication/logical/tablesync.c
+++ b/src/backend/replication/logical/tablesync.c
@@ -150,7 +150,7 @@ finish_sync_worker(void)
 	logicalrep_worker_wakeup(MyLogicalRepWorker->subid, InvalidOid);
 
 	/* Stop gracefully */
-	proc_exit(0);
+	pg_proc_exit(0);
 }
 
 /*

--- a/src/backend/replication/logical/worker.c
+++ b/src/backend/replication/logical/worker.c
@@ -2519,7 +2519,7 @@ maybe_reread_subscription(void)
 						"stop because the subscription was removed",
 						MySubscription->name)));
 
-		proc_exit(0);
+		pg_proc_exit(0);
 	}
 
 	/*
@@ -2533,7 +2533,7 @@ maybe_reread_subscription(void)
 						"stop because the subscription was disabled",
 						MySubscription->name)));
 
-		proc_exit(0);
+		pg_proc_exit(0);
 	}
 
 	/* !slotname should never happen when enabled is true. */
@@ -2554,7 +2554,7 @@ maybe_reread_subscription(void)
 				(errmsg("logical replication apply worker for subscription \"%s\" will restart because of a parameter change",
 						MySubscription->name)));
 
-		proc_exit(0);
+		pg_proc_exit(0);
 	}
 
 	/* Check for other changes that should never happen too. */
@@ -3100,7 +3100,7 @@ ApplyWorkerMain(Datum main_arg)
 				(errmsg("logical replication apply worker for subscription %u will not "
 						"start because the subscription was removed during startup",
 						MyLogicalRepWorker->subid)));
-		proc_exit(0);
+		pg_proc_exit(0);
 	}
 
 	MySubscriptionValid = true;
@@ -3113,7 +3113,7 @@ ApplyWorkerMain(Datum main_arg)
 						"start because the subscription was disabled during startup",
 						MySubscription->name)));
 
-		proc_exit(0);
+		pg_proc_exit(0);
 	}
 
 	/* Setup synchronous commit according to the user's wishes */
@@ -3221,7 +3221,7 @@ ApplyWorkerMain(Datum main_arg)
 	/* Run the main loop. */
 	LogicalRepApplyLoop(origin_startpos);
 
-	proc_exit(0);
+	pg_proc_exit(0);
 }
 
 /*

--- a/src/backend/replication/walreceiver.c
+++ b/src/backend/replication/walreceiver.c
@@ -209,7 +209,7 @@ WalReceiverMain(void)
 		case WALRCV_STOPPED:
 			SpinLockRelease(&walrcv->mutex);
 			ConditionVariableBroadcast(&walrcv->walRcvStoppedCV);
-			proc_exit(1);
+			pg_proc_exit(1);
 			break;
 
 		case WALRCV_STARTING:
@@ -647,7 +647,7 @@ WalRcvWaitForStartPosition(XLogRecPtr *startpoint, TimeLineID *startpointTLI)
 	{
 		SpinLockRelease(&walrcv->mutex);
 		if (state == WALRCV_STOPPING)
-			proc_exit(0);
+			pg_proc_exit(0);
 		else
 			elog(FATAL, "unexpected walreceiver state");
 	}

--- a/src/backend/replication/walsender.c
+++ b/src/backend/replication/walsender.c
@@ -318,7 +318,7 @@ WalSndErrorCleanup(void)
 		WalSndResourceCleanup(false);
 
 	if (got_STOPPING || got_SIGUSR2)
-		proc_exit(0);
+		pg_proc_exit(0);
 
 	/* Revert back to startup state */
 	WalSndSetState(WALSNDSTATE_STARTUP);
@@ -365,7 +365,7 @@ WalSndShutdown(void)
 	if (whereToSendOutput == DestRemote)
 		whereToSendOutput = DestNone;
 
-	proc_exit(0);
+	pg_proc_exit(0);
 	abort();					/* keep the compiler quiet */
 }
 
@@ -739,7 +739,7 @@ StartReplication(StartReplicationCmd *cmd)
 
 		replication_active = false;
 		if (got_STOPPING)
-			proc_exit(0);
+			pg_proc_exit(0);
 		WalSndSetState(WALSNDSTATE_STARTUP);
 
 		Assert(streamingDoneSending && streamingDoneReceiving);
@@ -1218,7 +1218,7 @@ StartLogicalReplication(StartReplicationCmd *cmd)
 
 	replication_active = false;
 	if (got_STOPPING)
-		proc_exit(0);
+		pg_proc_exit(0);
 	WalSndSetState(WALSNDSTATE_STARTUP);
 
 	/* Get out of COPY mode (CommandComplete). */
@@ -1732,7 +1732,7 @@ ProcessRepliesIfAny(void)
 			ereport(COMMERROR,
 					(errcode(ERRCODE_PROTOCOL_VIOLATION),
 					 errmsg("unexpected EOF on standby connection")));
-			proc_exit(0);
+			pg_proc_exit(0);
 		}
 		if (r == 0)
 		{
@@ -1767,7 +1767,7 @@ ProcessRepliesIfAny(void)
 			ereport(COMMERROR,
 					(errcode(ERRCODE_PROTOCOL_VIOLATION),
 					 errmsg("unexpected EOF on standby connection")));
-			proc_exit(0);
+			pg_proc_exit(0);
 		}
 
 		/* ... and process it */
@@ -1800,7 +1800,7 @@ ProcessRepliesIfAny(void)
 				 * 'X' means that the standby is closing down the socket.
 				 */
 			case 'X':
-				proc_exit(0);
+				pg_proc_exit(0);
 
 			default:
 				Assert(false);	/* NOT REACHED */
@@ -1844,7 +1844,7 @@ ProcessStandbyMessage(void)
 			ereport(COMMERROR,
 					(errcode(ERRCODE_PROTOCOL_VIOLATION),
 					 errmsg("unexpected message type \"%c\"", msgtype)));
-			proc_exit(0);
+			pg_proc_exit(0);
 	}
 }
 
@@ -2952,7 +2952,7 @@ WalSndDone(WalSndSendDataCallback send_data)
 		EndCommand(&qc, DestRemote, false);
 		pq_flush();
 
-		proc_exit(0);
+		pg_proc_exit(0);
 	}
 	if (!waiting_for_ping_response)
 		WalSndKeepalive(true);
@@ -3152,7 +3152,7 @@ WalSndWait(uint32 socket_events, long timeout, uint32 wait_event)
 	ModifyWaitEvent(FeBeWaitSet, FeBeWaitSetSocketPos, socket_events, NULL);
 	if (WaitEventSetWait(FeBeWaitSet, timeout, &event, 1, wait_event) == 1 &&
 		(event.events & WL_POSTMASTER_DEATH))
-		proc_exit(1);
+		pg_proc_exit(1);
 }
 
 /*

--- a/src/backend/storage/ipc/ipc.c
+++ b/src/backend/storage/ipc/ipc.c
@@ -33,7 +33,7 @@
 
 
 /*
- * This flag is set during proc_exit() to change ereport()'s behavior,
+ * This flag is set during pg_proc_exit() to change ereport()'s behavior,
  * so that an ereport() from an on_proc_exit routine cannot get us out
  * of the exit procedure.  We do NOT want to go back to the idle loop...
  */
@@ -101,7 +101,7 @@ static int	on_proc_exit_index,
  * ----------------------------------------------------------------
  */
 void
-proc_exit(int code)
+pg_proc_exit(int code)
 {
 	/* Clean up everything that must be cleaned up */
 	proc_exit_prepare(code);
@@ -193,7 +193,7 @@ proc_exit_prepare(int code)
 	/* do our shared memory exits first */
 	shmem_exit(code);
 
-	elog(DEBUG3, "proc_exit(%d): %d callbacks to make",
+	elog(DEBUG3, "pg_proc_exit(%d): %d callbacks to make",
 		 code, on_proc_exit_index);
 
 	/*
@@ -215,7 +215,7 @@ proc_exit_prepare(int code)
 /* ------------------
  * Run all of the on_shmem_exit routines --- but don't actually exit.
  * This is used by the postmaster to re-initialize shared memory and
- * semaphores after a backend dies horribly.  As with proc_exit(), we
+ * semaphores after a backend dies horribly.  As with pg_proc_exit(), we
  * remove each callback from the list before calling it, to avoid
  * infinite loop in case of error.
  * ------------------
@@ -298,7 +298,7 @@ atexit_callback(void)
  *		on_proc_exit
  *
  *		this function adds a callback function to the list of
- *		functions invoked by proc_exit().   -cim 2/6/90
+ *		functions invoked by pg_proc_exit().   -cim 2/6/90
  * ----------------------------------------------------------------
  */
 void

--- a/src/backend/storage/ipc/latch.c
+++ b/src/backend/storage/ipc/latch.c
@@ -1520,7 +1520,7 @@ WaitEventSetWaitBlock(WaitEventSet *set, int cur_timeout,
 			if (!PostmasterIsAliveInternal())
 			{
 				if (set->exit_on_postmaster_death)
-					proc_exit(1);
+					pg_proc_exit(1);
 				occurred_events->fd = PGINVALID_SOCKET;
 				occurred_events->events = WL_POSTMASTER_DEATH;
 				occurred_events++;
@@ -1593,7 +1593,7 @@ WaitEventSetWaitBlock(WaitEventSet *set, int cur_timeout,
 	if (unlikely(set->report_postmaster_not_running))
 	{
 		if (set->exit_on_postmaster_death)
-			proc_exit(1);
+			pg_proc_exit(1);
 		occurred_events->fd = PGINVALID_SOCKET;
 		occurred_events->events = WL_POSTMASTER_DEATH;
 		return 1;
@@ -1664,7 +1664,7 @@ WaitEventSetWaitBlock(WaitEventSet *set, int cur_timeout,
 			set->report_postmaster_not_running = true;
 
 			if (set->exit_on_postmaster_death)
-				proc_exit(1);
+				pg_proc_exit(1);
 			occurred_events->fd = PGINVALID_SOCKET;
 			occurred_events->events = WL_POSTMASTER_DEATH;
 			occurred_events++;
@@ -1784,7 +1784,7 @@ WaitEventSetWaitBlock(WaitEventSet *set, int cur_timeout,
 			if (!PostmasterIsAliveInternal())
 			{
 				if (set->exit_on_postmaster_death)
-					proc_exit(1);
+					pg_proc_exit(1);
 				occurred_events->fd = PGINVALID_SOCKET;
 				occurred_events->events = WL_POSTMASTER_DEATH;
 				occurred_events++;
@@ -1950,7 +1950,7 @@ WaitEventSetWaitBlock(WaitEventSet *set, int cur_timeout,
 		if (!PostmasterIsAliveInternal())
 		{
 			if (set->exit_on_postmaster_death)
-				proc_exit(1);
+				pg_proc_exit(1);
 			occurred_events->fd = PGINVALID_SOCKET;
 			occurred_events->events = WL_POSTMASTER_DEATH;
 			occurred_events++;

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -2903,7 +2903,7 @@ quickdie(SIGNAL_ARGS)
 	}
 
 	/*
-	 * We DO NOT want to run proc_exit() or atexit() callbacks -- we're here
+	 * We DO NOT want to run pg_proc_exit() or atexit() callbacks -- we're here
 	 * because shared memory may be corrupted, so we don't want to try to
 	 * clean up our transaction.  Just nail the windows shut and get out of
 	 * town.  The callbacks wouldn't be safe to run from a signal handler,
@@ -3174,7 +3174,7 @@ ProcessInterrupts(void)
 			 * The logical replication launcher can be stopped at any time.
 			 * Use exit status 1 so the background worker is restarted.
 			 */
-			proc_exit(1);
+			pg_proc_exit(1);
 		}
 		else if (RecoveryConflictPending && RecoveryConflictRetryable)
 		{
@@ -4040,7 +4040,7 @@ PostgresMain(int argc, char *argv[],
 	if (!IsUnderPostmaster)
 	{
 		if (!SelectConfigFiles(userDoption, progname))
-			proc_exit(1);
+			pg_proc_exit(1);
 	}
 
 	/*
@@ -4776,7 +4776,7 @@ PostgresMain_Part2()
 				 * it will fail to be called during other backend-shutdown
 				 * scenarios.
 				 */
-				proc_exit(0);
+				pg_proc_exit(0);
 
 			case 'd':			/* copy data */
 			case 'c':			/* copy done */

--- a/src/backend/utils/error/elog.c
+++ b/src/backend/utils/error/elog.c
@@ -663,7 +663,7 @@ errfinish(const char *filename, int lineno, const char *funcname)
 		 * FATAL termination.  The postmaster may or may not consider this
 		 * worthy of panic, depending on which subprocess returns it.
 		 */
-		proc_exit(1);
+		pg_proc_exit(1);
 	}
 
 	if (elevel >= PANIC)

--- a/src/backend/utils/fmgr/dfmgr.c
+++ b/src/backend/utils/fmgr/dfmgr.c
@@ -264,11 +264,11 @@ internal_load_library(const char *libname)
 		/*
 		 * Check for same files - different paths (ie, symlink or link)
 		 */
-		if (stat(libname, &stat_buf) == -1)
-			ereport(ERROR,
-					(errcode_for_file_access(),
-					 errmsg("could not access file \"%s\": %m",
-							libname)));
+		// if (stat(libname, &stat_buf) == -1)
+		// 	ereport(ERROR,
+		// 			(errcode_for_file_access(),
+		// 			 errmsg("could not access file \"%s\": %m",
+		// 					libname)));
 
 		for (file_scanner = file_list;
 			 file_scanner != NULL &&

--- a/src/backend/utils/init/miscinit.c
+++ b/src/backend/utils/init/miscinit.c
@@ -115,7 +115,7 @@ InitPostmasterChild(void)
 	_setmode(fileno(stderr), _O_BINARY);
 #endif
 
-	/* We don't want the postmaster's proc_exit() handlers */
+	/* We don't want the postmaster's pg_proc_exit() handlers */
 	on_exit_reset();
 
 	/* In EXEC_BACKEND case we will not have inherited BlockSig etc values */
@@ -951,7 +951,7 @@ UnlinkLockFiles(int status, Datum arg)
 	 * of a postmaster or standalone backend, while we won't come here at all
 	 * when exiting postmaster child processes.  Therefore, this is a good
 	 * place to log completion of shutdown.  We could alternatively teach
-	 * proc_exit() to do it, but that seems uglier.  In a standalone backend,
+	 * pg_proc_exit() to do it, but that seems uglier.  In a standalone backend,
 	 * use NOTICE elevel to be less chatty.
 	 */
 	ereport(IsPostmasterEnvironment ? LOG : NOTICE,

--- a/src/include/executor/executor.h
+++ b/src/include/executor/executor.h
@@ -237,7 +237,7 @@ extern PlanState *ExecInitNode(Plan *node, EState *estate, int eflags);
 extern void ExecSetExecProcNode(PlanState *node, ExecProcNodeMtd function);
 extern Node *MultiExecProcNode(PlanState *node);
 extern void ExecEndNode(PlanState *node);
-extern bool ExecShutdownNode(PlanState *node);
+extern void ExecShutdownNode(PlanState *node);
 extern void ExecSetTupleBound(int64 tuples_needed, PlanState *child_node);
 
 

--- a/src/include/storage/ipc.h
+++ b/src/include/storage/ipc.h
@@ -65,7 +65,7 @@ typedef void (*shmem_startup_hook_type) (void);
 extern PGDLLIMPORT bool proc_exit_inprogress;
 extern PGDLLIMPORT bool shmem_exit_inprogress;
 
-extern void proc_exit(int code) pg_attribute_noreturn();
+extern void pg_proc_exit(int code) pg_attribute_noreturn();
 extern void shmem_exit(int code);
 extern void on_proc_exit(pg_on_exit_callback function, Datum arg);
 extern void on_shmem_exit(pg_on_exit_callback function, Datum arg);

--- a/src/include/utils/elog.h
+++ b/src/include/utils/elog.h
@@ -296,7 +296,7 @@ extern PGDLLIMPORT ErrorContextCallback *error_context_stack;
  * not before popping the error stack.
  *
  * Note: an ereport(FATAL) will not be caught by this construct; control will
- * exit straight through proc_exit().  Therefore, do NOT put any cleanup
+ * exit straight through pg_proc_exit().  Therefore, do NOT put any cleanup
  * of non-process-local resources into the error recovery section, at least
  * not without taking thought for what will happen during ereport(FATAL).
  * The PG_ENSURE_ERROR_CLEANUP macros provided by storage/ipc.h may be

--- a/src/test/modules/test_shm_mq/worker.c
+++ b/src/test/modules/test_shm_mq/worker.c
@@ -126,7 +126,7 @@ test_shm_mq_main(Datum main_arg)
 	if (registrant == NULL)
 	{
 		elog(DEBUG1, "registrant backend has exited prematurely");
-		proc_exit(1);
+		pg_proc_exit(1);
 	}
 	SetLatch(&registrant->procLatch);
 
@@ -138,7 +138,7 @@ test_shm_mq_main(Datum main_arg)
 	 * segment (that would happen anyway during process exit, though).
 	 */
 	dsm_detach(seg);
-	proc_exit(1);
+	pg_proc_exit(1);
 }
 
 /*


### PR DESCRIPTION
- To enable dynamic linking we need to compile postgres with `MAIN_MODULE=1`, but it will export all postgres symbols to JS, in emscripten there's a [bug](https://github.com/emscripten-core/emscripten/issues/22205) related to symbol collision issue with WASI symbols. Postgres has symbol `proc_exit`  and symbol with the same name also exists in WASI runtime, so after exporting this symbol we are getting runtime error that `proc_exit` from `wasi_snapshot_preview_1` is not found. I have renamed postgres symbol to `pg_proc_exit` to fix the issue  until the fix from emscripten will be available. This may only break extensions which are using the `proc_exit` function from postgres.
- Fixed function pointer casts issue by applying patch: https://github.com/postgres/postgres/commit/c35ba141de1fa04373671ba24c73eb0fe4862415.patch . Thus we can drop `EMULATE_FUNCTION_POINTER_CASTS` flag, so `dlsym` could work.
- Comment out extension file check in `dfmgr.c` to allow passing any URL for extension wasm file as now the extension control file can contain full URL to wasm file under `module_pathname`